### PR TITLE
Add iOS SDK 4.17.1 changelog and reference link

### DIFF
--- a/other/changelog/ios-sdk/v4.md
+++ b/other/changelog/ios-sdk/v4.md
@@ -8,6 +8,19 @@ MapsIndoors iOS SDK v4 requires at least iOS 15 and Xcode 16.
 
 {% include "../../../.gitbook/includes/ios-xcode-16-requirement.md" %}
 
+### \[4.17.1] 2026-06-09
+
+#### Added
+
+* Added a method for cross-platform wrappers (such as Flutter and React Native) to report which platform is driving MapsIndoors, so it is reflected correctly in logging.
+
+#### Fixed
+
+* Routes no longer disappear when changing legs, and automatic floor detection no longer overrides the floor pinned for an active route.
+* `mapPadding` is now applied to the camera target when fitting a route and when detecting the current venue and building, on both Google Maps and Mapbox.
+* Tapping the map now selects the room under the tap point instead of an occasionally adjacent room, which was most noticeable when zoomed out \[Mapbox].
+* The Mapbox logo no longer overlaps the MapsPeople logo \[Mapbox only].
+
 ### \[4.17.0] 2026-05-12
 
 #### Added

--- a/reference-docs/ios-sdk.md
+++ b/reference-docs/ios-sdk.md
@@ -9,11 +9,12 @@ icon: apple
 {% tab title="v4" %}
 **Latest**[**​**](https://docs.mapsindoors.com/reference-docs/ios#latest-1)
 
-<table data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>4.17.0</strong></td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.0/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.0/documentation/mapsindoors/</a></td></tr></tbody></table>
+<table data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>4.17.1</strong></td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.1/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.1/documentation/mapsindoors/</a></td></tr></tbody></table>
 
 **Previous versions**[**​**](https://docs.mapsindoors.com/reference-docs/ios#previous-versions)
 
 <table data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody>
+<tr><td>4.17.0</td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.0/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.0/documentation/mapsindoors/</a></td></tr>
 <tr><td>4.16.5</td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.16.5/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.16.5/documentation/mapsindoors/</a></td></tr>
 <tr><td>4.16.4</td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.16.4/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.16.4/documentation/mapsindoors/</a></td></tr>
 <tr><td>4.16.3</td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.16.3/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.16.3/documentation/mapsindoors/</a></td></tr>


### PR DESCRIPTION
Adds the iOS SDK 4.17.1 changelog entry to `other/changelog/ios-sdk/v4.md` and promotes 4.17.1 to Latest in `reference-docs/ios-sdk.md` (4.17.0 moved to Previous versions), as part of the 4.17.1 release (SPEX-1920). Mirrors the 4.17.0 docs PR (#213).

Changelog covers the "iOS SDK 4.17.1" fixVersion:
- Added: method for cross-platform wrappers (Flutter/RN) to report the driving platform (SPEX-1815)
- Fixed: route/floor on leg change (SPEX-1922), mapPadding on camera target (SPEX-1910), nearest-room tap (SPEX-1903), Mapbox logo overlap (SPEX-1786)
