### PR TITLE
Remove Added section from iOS 4.17.1 changelog and update date

### DIFF
--- a/other/changelog/ios-sdk/v4.md
+++ b/other/changelog/ios-sdk/v4.md
@@ -8,11 +8,7 @@ MapsIndoors iOS SDK v4 requires at least iOS 15 and Xcode 16.
 
 {% include "../../../.gitbook/includes/ios-xcode-16-requirement.md" %}
 
-### \[4.17.1] 2026-06-09
-
-#### Added
-
-* Added a method for cross-platform wrappers (such as Flutter and React Native) to report which platform is driving MapsIndoors, so it is reflected correctly in logging.
+### \[4.17.1] 2026-06-10
 
 #### Fixed
 


### PR DESCRIPTION
Follow-up to #219. Removes the `#### Added` section (the cross-platform-wrappers / SPEX-1815 entry) from the iOS SDK 4.17.1 changelog and updates the release date from 2026-06-09 to 2026-06-10.

Only `other/changelog/ios-sdk/v4.md` is touched; the four `#### Fixed` bullets are unchanged.

After merge, the `documentation` submodule pointer in MISDKIOS `v4_develop` must be re-bumped to this commit before tagging 4.17.1.