### PR TITLE
Add iOS SDK 4.17.3 changelog and reference link

### DIFF
--- a/other/changelog/ios-sdk/v4.md
+++ b/other/changelog/ios-sdk/v4.md
@@ -8,6 +8,12 @@ MapsIndoors iOS SDK v4 requires at least iOS 15 and Xcode 16.
 
 {% include "../../../.gitbook/includes/ios-xcode-16-requirement.md" %}
 
+### \[4.17.3] 2026-06-17
+
+#### Fixed
+
+* Updates made in the CMS to location data — most visibly polygon geometry and 3D extrusion heights — are now reflected on subsequent loads and across app restarts, instead of remaining stuck on previously cached data.
+
 ### \[4.17.2] 2026-06-12
 
 #### Fixed

--- a/reference-docs/ios-sdk.md
+++ b/reference-docs/ios-sdk.md
@@ -9,11 +9,12 @@ icon: apple
 {% tab title="v4" %}
 **Latest**[**​**](https://docs.mapsindoors.com/reference-docs/ios#latest-1)
 
-<table data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>4.17.2</strong></td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.2/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.2/documentation/mapsindoors/</a></td></tr></tbody></table>
+<table data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>4.17.3</strong></td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.3/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.3/documentation/mapsindoors/</a></td></tr></tbody></table>
 
 **Previous versions**[**​**](https://docs.mapsindoors.com/reference-docs/ios#previous-versions)
 
 <table data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody>
+<tr><td>4.17.2</td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.2/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.2/documentation/mapsindoors/</a></td></tr>
 <tr><td>4.17.1</td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.1/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.1/documentation/mapsindoors/</a></td></tr>
 <tr><td>4.17.0</td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.0/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.0/documentation/mapsindoors/</a></td></tr>
 <tr><td>4.16.5</td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.16.5/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.16.5/documentation/mapsindoors/</a></td></tr>


### PR DESCRIPTION
Adds the changelog entry and reference-docs link for the iOS SDK **4.17.3** hotfix release (SPEX-1981).

### Changes
- `other/changelog/ios-sdk/v4.md` — new `[4.17.3]` entry under Fixed.
- `reference-docs/ios-sdk.md` — promote 4.17.3 to Latest, move 4.17.2 to Previous versions.

### Release note
> Updates made in the CMS to location data — most visibly polygon geometry and 3D extrusion heights — are now reflected on subsequent loads and across app restarts, instead of remaining stuck on previously cached data.