### PR TITLE
[DO NOT MERGE until 4.18.0 released] iOS SDK 4.18.0 docs: raise minimum requirements [SPEX-1719]

### DIFF
--- a/.gitbook/includes/ios-xcode-16-requirement.md
+++ b/.gitbook/includes/ios-xcode-16-requirement.md
@@ -1,7 +1,7 @@
 ---
-title: iOS Xcode 16 requirement
+title: iOS and Xcode requirement
 ---
 
 {% hint style="info" %}
-From version 4.10.0 (the first minor release after April 24, 2025) MapsIndoors requires a minimum iOS version of 15 and Xcode 16 as [Apple now requires apps to be built with Xcode 16](https://developer.apple.com/news/upcoming-requirements/?id=02212025a) to be distributed via App Store.
+From version 4.18.0 (released June 30, 2026) MapsIndoors requires a minimum iOS version of 16 and Xcode 26. Earlier 4.x releases (from 4.10.0) required iOS 15 and Xcode 16, when [Apple began requiring apps to be built with Xcode 16](https://developer.apple.com/news/upcoming-requirements/?id=02212025a) to be distributed via the App Store.
 {% endhint %}

--- a/other/changelog/ios-sdk/v4.md
+++ b/other/changelog/ios-sdk/v4.md
@@ -2,11 +2,18 @@
 
 ### iOS Version Requirements <a href="#ios-version-requirements" id="ios-version-requirements"></a>
 
-MapsIndoors iOS SDK v4 requires at least iOS 15 and Xcode 16.
+MapsIndoors iOS SDK v4 requires at least iOS 16 and Xcode 26.
 
 {% include "../../../.gitbook/includes/cocoapods-is-soon-going-int....md" %}
 
 {% include "../../../.gitbook/includes/ios-xcode-16-requirement.md" %}
+
+### \[4.18.0] 2026-06-30
+
+#### Changed
+
+* Raised the minimum requirements to iOS 16 and Xcode 26 (previously iOS 15 and Xcode 16).
+* Google routing now uses the Google Routes API, falling back to the legacy Directions and Distance Matrix APIs when the Routes API is unavailable. This restores routing to and from outside a venue for projects that cannot enable the legacy Google APIs.
 
 ### \[4.17.3] 2026-06-17
 

--- a/other/technical-requirements.md
+++ b/other/technical-requirements.md
@@ -14,8 +14,8 @@ JDK source: 11
 
 ### iOS SDK
 
-Minimum iOS 15\
-Minimum Xcode 16
+Minimum iOS 16\
+Minimum Xcode 26
 
 ### Flutter
 

--- a/reference-docs/ios-sdk.md
+++ b/reference-docs/ios-sdk.md
@@ -9,11 +9,12 @@ icon: apple
 {% tab title="v4" %}
 **Latest**[**​**](https://docs.mapsindoors.com/reference-docs/ios#latest-1)
 
-<table data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>4.17.3</strong></td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.3/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.3/documentation/mapsindoors/</a></td></tr></tbody></table>
+<table data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>4.18.0</strong></td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.18.0/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.18.0/documentation/mapsindoors/</a></td></tr></tbody></table>
 
 **Previous versions**[**​**](https://docs.mapsindoors.com/reference-docs/ios#previous-versions)
 
 <table data-view="cards"><thead><tr><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody>
+<tr><td>4.17.3</td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.3/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.3/documentation/mapsindoors/</a></td></tr>
 <tr><td>4.17.2</td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.2/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.2/documentation/mapsindoors/</a></td></tr>
 <tr><td>4.17.1</td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.1/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.1/documentation/mapsindoors/</a></td></tr>
 <tr><td>4.17.0</td><td><a href="https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.0/documentation/mapsindoors/">https://app.mapsindoors.com/mapsindoors/reference/ios/4.17.0/documentation/mapsindoors/</a></td></tr>


### PR DESCRIPTION
## Hold until 4.18.0 ships

**Do not merge until the iOS SDK 4.18.0 release is published.** These docs describe the 4.18.0 release state (minimum iOS 16 / Xcode 26). The live doc site publishes from `main`, so merging early would tell customers the minimum is iOS 16 while the current release (4.17.3) still requires iOS 15.

## Changes (SPEX-1719)

- **Changelog** (`other/changelog/ios-sdk/v4.md`): added the `[4.18.0]` entry (requirements bump + Google Routes API migration) and reworded the top requirements note to iOS 16 / Xcode 26.
- **Reference link** (`reference-docs/ios-sdk.md`): promoted 4.18.0 to *Latest*, moved 4.17.3 to *Previous versions* (same pattern as prior releases).
- **Technical Requirements** (`other/technical-requirements.md`): iOS 15 → 16, Xcode 16 → 26.
- **Requirement include** (`.gitbook/includes/ios-xcode-16-requirement.md`): reworded for the new minimum, kept the 4.10.0 history.

## Out of scope

- Xcode 26 screenshots on the *create-a-new-project* page (SPEX-1772) — Christian will do those in Gitbook (images + proprietary Markdown).