### PR TITLE
Reword iOS minimum requirement to iOS 16.6 / Xcode 26 [SPEX-1719]

### DIFF
--- a/other/changelog/ios-sdk/v4.md
+++ b/other/changelog/ios-sdk/v4.md
@@ -2,7 +2,7 @@
 
 ### iOS Version Requirements <a href="#ios-version-requirements" id="ios-version-requirements"></a>
 
-MapsIndoors iOS SDK v4 requires at least iOS 15 and Xcode 16.
+MapsIndoors iOS SDK v4 requires at least iOS 16.6 and Xcode 26.
 
 {% include "../../../.gitbook/includes/cocoapods-is-soon-going-int....md" %}
 

--- a/other/changelog/ios-sdk/v4.md
+++ b/other/changelog/ios-sdk/v4.md
@@ -2,7 +2,7 @@
 
 ### iOS Version Requirements <a href="#ios-version-requirements" id="ios-version-requirements"></a>
 
-MapsIndoors iOS SDK v4 requires at least iOS 16.6 and Xcode 26.
+MapsIndoors iOS SDK v4 requires at least iOS 16 and Xcode 26.
 
 {% include "../../../.gitbook/includes/cocoapods-is-soon-going-int....md" %}
 

--- a/other/technical-requirements.md
+++ b/other/technical-requirements.md
@@ -16,8 +16,8 @@ JDK source: 11
 
 {% include "../.gitbook/includes/ios-xcode-26-requirement.md" %}
 
-Minimum iOS 15\
-Minimum Xcode 16
+Minimum iOS 16.6\
+Minimum Xcode 26
 
 ### Flutter
 

--- a/other/technical-requirements.md
+++ b/other/technical-requirements.md
@@ -16,7 +16,7 @@ JDK source: 11
 
 {% include "../.gitbook/includes/ios-xcode-26-requirement.md" %}
 
-Minimum iOS 16.6\
+Minimum iOS 16\
 Minimum Xcode 26
 
 ### Flutter


### PR DESCRIPTION
Aligns the stale base text with the already-published Xcode 26 requirement hint.

- **Changelog** (`other/changelog/ios-sdk/v4.md`): "requires at least iOS 15 and Xcode 16" → "iOS 16.6 and Xcode 26".
- **Technical Requirements** (`other/technical-requirements.md`): "Minimum iOS 15 / Xcode 16" → "iOS 16.6 / Xcode 26".

Builds on top of the current `main` (incl. the `ios-xcode-26-requirement.md` hint); does not touch any include. The base text previously still read 15/16.

Note: this makes the base text a blanket 16.6 requirement, so it pairs with the **4.18.0 release** — merge with/after 4.18.0 ships (the current released version is 4.17.3).